### PR TITLE
Fix Teams not Showing Up in Sandbox

### DIFF
--- a/openpermissions/lua/openpermissions/cl.lua
+++ b/openpermissions/lua/openpermissions/cl.lua
@@ -584,13 +584,13 @@ function OpenPermissions:OpenMenu(specific_addon)
 						end
 					else
 						local teams = {}
-						for i,t in ipairs(team.GetAllTeams()) do
+						for i,t in pairs(team.GetAllTeams()) do
 							table.insert(teams, {Name = t.Name, Index = i, Color = t.Color})
 						end
 						table.SortByMember(teams, "Name", true)
 						for i,item in ipairs(teams) do
 							DMenuOption_ColorIcon(ACCESS_GROUP_TEAM:AddOption(item.Name, function()
-								AddAccessGroup:Add(OpenPermissions.ACCESS_GROUP.TEAM, item.Name, OpenPermissions:GetTeamIdentifier(i))
+								AddAccessGroup:Add(OpenPermissions.ACCESS_GROUP.TEAM, item.Name, OpenPermissions:GetTeamIdentifier(item.Index))
 							end), item.Color)
 						end
 					end

--- a/openpermissions/lua/openpermissions/sh.lua
+++ b/openpermissions/lua/openpermissions/sh.lua
@@ -517,7 +517,7 @@ function OpenPermissions:GetTeamFromIdentifier(team_identifier)
 			end
 		end
 	else
-		for i,t in ipairs(team.GetAllTeams()) do
+		for i,t in pairs(team.GetAllTeams()) do
 			if (t.Name == team_identifier) then
 				team_identifier_index[team_identifier] = i
 				return i


### PR DESCRIPTION
![image](https://github.com/GmodAdminSuite/OpenPermissions/assets/66616587/3a96032f-7ffd-4cc0-8410-ff73038e8a06)


The indices are not sequentially in the sandbox gamemode. This causes no available Team to show up.

This Problem also has to be fixed in GmodAdminSuite
